### PR TITLE
Feature/add utc with progressive bias

### DIFF
--- a/src/main/kingdominoplayer/tinyrepresentation/gamestrategies/TinyMonteCarloTreeSearchPB.java
+++ b/src/main/kingdominoplayer/tinyrepresentation/gamestrategies/TinyMonteCarloTreeSearchPB.java
@@ -1,18 +1,20 @@
 package kingdominoplayer.tinyrepresentation.gamestrategies;
 
+/*
+ * Copyright 2018 Tomologic AB<br>
+ * User: gedda<br>
+ * Date: 2018-01-23<br>
+ * Time: 20:44<br><br>
+ */
+
 import kingdominoplayer.SearchParameters;
 import kingdominoplayer.tinyrepresentation.datastructures.TinyGameState;
 import kingdominoplayer.tinyrepresentation.search.montecarlo.treesearch.ucts.UCB;
+import kingdominoplayer.tinyrepresentation.search.montecarlo.treesearch.ucts.UCBProgressiveBias;
 import kingdominoplayer.tinyrepresentation.search.montecarlo.treesearch.ucts.UCTSearch;
 import kingdominoplayer.tinyrepresentation.simulationstrategies.TinySimulationStrategy;
 
-/**
- * Copyright 2017 Tomologic AB<br>
- * User: gedda<br>
- * Date: 2017-03-21<br>
- * Time: 14:31<br><br>
- */
-public class TinyMonteCarloTreeSearch implements TinyStrategy
+public class TinyMonteCarloTreeSearchPB implements TinyStrategy
 {
 
     private final TinySimulationStrategy iSimulationStrategy;
@@ -21,13 +23,14 @@ public class TinyMonteCarloTreeSearch implements TinyStrategy
     private final UCB iUCB;
     private UCTSearch iSearchAlgorithm;
 
-    public TinyMonteCarloTreeSearch(final TinySimulationStrategy simulationStrategy,
-                                    final SearchParameters searchParameters,
-                                    final double exploreFactor)
+    public TinyMonteCarloTreeSearchPB(final TinySimulationStrategy simulationStrategy,
+                                      final SearchParameters searchParameters,
+                                      final double exploreFactor,
+                                      final double biasWeight)
     {
         iSimulationStrategy = simulationStrategy;
         iSearchParameters = searchParameters;
-        iUCB = new UCB(exploreFactor);
+        iUCB = new UCBProgressiveBias(exploreFactor, biasWeight);
     }
 
     @Override
@@ -44,4 +47,5 @@ public class TinyMonteCarloTreeSearch implements TinyStrategy
         assert iSearchAlgorithm != null : "Search algorithm not initialized yet!";
         return iSearchAlgorithm.getNumPlayoutsPerSecond();
     }
+
 }

--- a/src/main/kingdominoplayer/tinyrepresentation/gamestrategies/TinyMonteCarloTreeSearchWPB.java
+++ b/src/main/kingdominoplayer/tinyrepresentation/gamestrategies/TinyMonteCarloTreeSearchWPB.java
@@ -1,18 +1,20 @@
 package kingdominoplayer.tinyrepresentation.gamestrategies;
 
+/*
+ * Copyright 2018 Tomologic AB<br>
+ * User: gedda<br>
+ * Date: 2018-01-23<br>
+ * Time: 20:41<br><br>
+ */
+
 import kingdominoplayer.SearchParameters;
 import kingdominoplayer.tinyrepresentation.datastructures.TinyGameState;
 import kingdominoplayer.tinyrepresentation.search.montecarlo.treesearch.ucts.UCB;
+import kingdominoplayer.tinyrepresentation.search.montecarlo.treesearch.ucts.UCBWinPersistentProgressiveBias;
 import kingdominoplayer.tinyrepresentation.search.montecarlo.treesearch.ucts.UCTSearch;
 import kingdominoplayer.tinyrepresentation.simulationstrategies.TinySimulationStrategy;
 
-/**
- * Copyright 2017 Tomologic AB<br>
- * User: gedda<br>
- * Date: 2017-03-21<br>
- * Time: 14:31<br><br>
- */
-public class TinyMonteCarloTreeSearch implements TinyStrategy
+public class TinyMonteCarloTreeSearchWPB implements TinyStrategy
 {
 
     private final TinySimulationStrategy iSimulationStrategy;
@@ -21,13 +23,14 @@ public class TinyMonteCarloTreeSearch implements TinyStrategy
     private final UCB iUCB;
     private UCTSearch iSearchAlgorithm;
 
-    public TinyMonteCarloTreeSearch(final TinySimulationStrategy simulationStrategy,
-                                    final SearchParameters searchParameters,
-                                    final double exploreFactor)
+    public TinyMonteCarloTreeSearchWPB(final TinySimulationStrategy simulationStrategy,
+                                       final SearchParameters searchParameters,
+                                       final double exploreFactor,
+                                       final double biasWeight)
     {
         iSimulationStrategy = simulationStrategy;
         iSearchParameters = searchParameters;
-        iUCB = new UCB(exploreFactor);
+        iUCB = new UCBWinPersistentProgressiveBias(exploreFactor, biasWeight);
     }
 
     @Override
@@ -44,4 +47,5 @@ public class TinyMonteCarloTreeSearch implements TinyStrategy
         assert iSearchAlgorithm != null : "Search algorithm not initialized yet!";
         return iSearchAlgorithm.getNumPlayoutsPerSecond();
     }
+
 }

--- a/src/main/kingdominoplayer/tinyrepresentation/gamestrategies/TinyStrategyFactory.java
+++ b/src/main/kingdominoplayer/tinyrepresentation/gamestrategies/TinyStrategyFactory.java
@@ -58,85 +58,89 @@ public class TinyStrategyFactory
                 result = new TinyMonteCarloEvaluation(new TinyAllMoves(), new TinyPlayerGreedySimulationStrategy(), new RelativeScoreFunction(), iSearchParameters);
                 break;
 
-            case UCT_TR_C0_1_W0_0:
-                result = new TinyMonteCarloTreeSearch(new TinyTrueRandomSimulationStrategy(), iSearchParameters, 0.1, 0.0);
+            case UCT_TR_C0_1:
+                result = new TinyMonteCarloTreeSearch(new TinyTrueRandomSimulationStrategy(), iSearchParameters, 0.1);
                 break;
-            case UCT_TR_C0_2_W0_0:
-                result = new TinyMonteCarloTreeSearch(new TinyTrueRandomSimulationStrategy(), iSearchParameters, 0.2, 0.0);
+            case UCT_TR_C0_2:
+                result = new TinyMonteCarloTreeSearch(new TinyTrueRandomSimulationStrategy(), iSearchParameters, 0.2);
                 break;
-            case UCT_TR_C0_3_W0_0:
-                result = new TinyMonteCarloTreeSearch(new TinyTrueRandomSimulationStrategy(), iSearchParameters, 0.3, 0.0);
+            case UCT_TR_C0_3:
+                result = new TinyMonteCarloTreeSearch(new TinyTrueRandomSimulationStrategy(), iSearchParameters, 0.3);
                 break;
-            case UCT_TR_C0_4_W0_0:
-                result = new TinyMonteCarloTreeSearch(new TinyTrueRandomSimulationStrategy(), iSearchParameters, 0.4, 0.0);
+            case UCT_TR_C0_4:
+                result = new TinyMonteCarloTreeSearch(new TinyTrueRandomSimulationStrategy(), iSearchParameters, 0.4);
                 break;
-            case UCT_TR_C0_5_W0_0:
-                result = new TinyMonteCarloTreeSearch(new TinyTrueRandomSimulationStrategy(), iSearchParameters, 0.5, 0.0);
+            case UCT_TR_C0_5:
+                result = new TinyMonteCarloTreeSearch(new TinyTrueRandomSimulationStrategy(), iSearchParameters, 0.5);
                 break;
-            case UCT_TR_C0_6_W0_0:
-                result = new TinyMonteCarloTreeSearch(new TinyTrueRandomSimulationStrategy(), iSearchParameters, 0.6, 0.0);
+            case UCT_TR_C0_6:
+                result = new TinyMonteCarloTreeSearch(new TinyTrueRandomSimulationStrategy(), iSearchParameters, 0.6);
                 break;
-            case UCT_TR_C1_0_W0_0:
-                result = new TinyMonteCarloTreeSearch(new TinyTrueRandomSimulationStrategy(), iSearchParameters, 1.0, 0.0);
+            case UCT_TR_C1_0:
+                result = new TinyMonteCarloTreeSearch(new TinyTrueRandomSimulationStrategy(), iSearchParameters, 1.0);
                 break;
-            case UCT_TR_C1_5_W0_0:
-                result = new TinyMonteCarloTreeSearch(new TinyTrueRandomSimulationStrategy(), iSearchParameters, 1.5, 0.0);
+            case UCT_TR_C1_5:
+                result = new TinyMonteCarloTreeSearch(new TinyTrueRandomSimulationStrategy(), iSearchParameters, 1.5);
                 break;
-            case UCT_TR_C2_0_W0_0:
-                result = new TinyMonteCarloTreeSearch(new TinyTrueRandomSimulationStrategy(), iSearchParameters, 2.0, 0.0);
-                break;
-
-            case UCT_FG_C0_1_W0_0:
-                result = new TinyMonteCarloTreeSearch(new TinyFullGreedySimulationStrategy(), iSearchParameters, 0.1, 0.0);
-                break;
-            case UCT_FG_C0_2_W0_0:
-                result = new TinyMonteCarloTreeSearch(new TinyFullGreedySimulationStrategy(), iSearchParameters, 0.2, 0.0);
-                break;
-            case UCT_FG_C0_3_W0_0:
-                result = new TinyMonteCarloTreeSearch(new TinyFullGreedySimulationStrategy(), iSearchParameters, 0.3, 0.0);
-                break;
-            case UCT_FG_C0_4_W0_0:
-                result = new TinyMonteCarloTreeSearch(new TinyFullGreedySimulationStrategy(), iSearchParameters, 0.4, 0.0);
-                break;
-            case UCT_FG_C0_5_W0_0:
-                result = new TinyMonteCarloTreeSearch(new TinyFullGreedySimulationStrategy(), iSearchParameters, 0.5, 0.0);
-                break;
-            case UCT_FG_C0_6_W0_0:
-                result = new TinyMonteCarloTreeSearch(new TinyFullGreedySimulationStrategy(), iSearchParameters, 0.6, 0.0);
-                break;
-            case UCT_FG_C1_0_W0_0:
-                result = new TinyMonteCarloTreeSearch(new TinyFullGreedySimulationStrategy(), iSearchParameters, 1.0, 0.0);
-                break;
-            case UCT_FG_C1_5_W0_0:
-                result = new TinyMonteCarloTreeSearch(new TinyFullGreedySimulationStrategy(), iSearchParameters, 1.5, 0.0);
-                break;
-            case UCT_FG_C2_0_W0_0:
-                result = new TinyMonteCarloTreeSearch(new TinyFullGreedySimulationStrategy(), iSearchParameters, 2.0, 0.0);
+            case UCT_TR_C2_0:
+                result = new TinyMonteCarloTreeSearch(new TinyTrueRandomSimulationStrategy(), iSearchParameters, 2.0);
                 break;
 
-            case UCT_TR_C0_5_W0_1:
-                result = new TinyMonteCarloTreeSearch(new TinyTrueRandomSimulationStrategy(), iSearchParameters, 0.5, 0.1);
+            case UCT_FG_C0_1:
+                result = new TinyMonteCarloTreeSearch(new TinyFullGreedySimulationStrategy(), iSearchParameters, 0.1);
                 break;
-            case UCT_TR_C0_5_W0_2:
-                result = new TinyMonteCarloTreeSearch(new TinyTrueRandomSimulationStrategy(), iSearchParameters, 0.5, 0.2);
+            case UCT_FG_C0_2:
+                result = new TinyMonteCarloTreeSearch(new TinyFullGreedySimulationStrategy(), iSearchParameters, 0.2);
                 break;
-            case UCT_TR_C0_5_W0_3:
-                result = new TinyMonteCarloTreeSearch(new TinyTrueRandomSimulationStrategy(), iSearchParameters, 0.5, 0.3);
+            case UCT_FG_C0_3:
+                result = new TinyMonteCarloTreeSearch(new TinyFullGreedySimulationStrategy(), iSearchParameters, 0.3);
                 break;
-            case UCT_TR_C0_5_W0_4:
-                result = new TinyMonteCarloTreeSearch(new TinyTrueRandomSimulationStrategy(), iSearchParameters, 0.5, 0.4);
+            case UCT_FG_C0_4:
+                result = new TinyMonteCarloTreeSearch(new TinyFullGreedySimulationStrategy(), iSearchParameters, 0.4);
                 break;
-            case UCT_TR_C0_5_W0_5:
-                result = new TinyMonteCarloTreeSearch(new TinyTrueRandomSimulationStrategy(), iSearchParameters, 0.5, 0.5);
+            case UCT_FG_C0_5:
+                result = new TinyMonteCarloTreeSearch(new TinyFullGreedySimulationStrategy(), iSearchParameters, 0.5);
                 break;
-            case UCT_TR_C0_5_W1_0:
-                result = new TinyMonteCarloTreeSearch(new TinyTrueRandomSimulationStrategy(), iSearchParameters, 0.5, 1.0);
+            case UCT_FG_C0_6:
+                result = new TinyMonteCarloTreeSearch(new TinyFullGreedySimulationStrategy(), iSearchParameters, 0.6);
                 break;
-            case UCT_TR_C0_5_W1_5:
-                result = new TinyMonteCarloTreeSearch(new TinyTrueRandomSimulationStrategy(), iSearchParameters, 0.5, 1.5);
+            case UCT_FG_C1_0:
+                result = new TinyMonteCarloTreeSearch(new TinyFullGreedySimulationStrategy(), iSearchParameters, 1.0);
                 break;
-            case UCT_TR_C0_5_W2_0:
-                result = new TinyMonteCarloTreeSearch(new TinyTrueRandomSimulationStrategy(), iSearchParameters, 0.5, 2.0);
+            case UCT_FG_C1_5:
+                result = new TinyMonteCarloTreeSearch(new TinyFullGreedySimulationStrategy(), iSearchParameters, 1.5);
+                break;
+            case UCT_FG_C2_0:
+                result = new TinyMonteCarloTreeSearch(new TinyFullGreedySimulationStrategy(), iSearchParameters, 2.0);
+                break;
+
+            case UCT_WPB_TR_C0_5_W0_1:
+                result = new TinyMonteCarloTreeSearchWPB(new TinyTrueRandomSimulationStrategy(), iSearchParameters, 0.5, 0.1);
+                break;
+            case UCT_WPB_TR_C0_5_W0_2:
+                result = new TinyMonteCarloTreeSearchWPB(new TinyTrueRandomSimulationStrategy(), iSearchParameters, 0.5, 0.2);
+                break;
+            case UCT_WPB_TR_C0_5_W0_3:
+                result = new TinyMonteCarloTreeSearchWPB(new TinyTrueRandomSimulationStrategy(), iSearchParameters, 0.5, 0.3);
+                break;
+            case UCT_WPB_TR_C0_5_W0_4:
+                result = new TinyMonteCarloTreeSearchWPB(new TinyTrueRandomSimulationStrategy(), iSearchParameters, 0.5, 0.4);
+                break;
+            case UCT_WPB_TR_C0_5_W0_5:
+                result = new TinyMonteCarloTreeSearchWPB(new TinyTrueRandomSimulationStrategy(), iSearchParameters, 0.5, 0.5);
+                break;
+            case UCT_WPB_TR_C0_5_W1_0:
+                result = new TinyMonteCarloTreeSearchWPB(new TinyTrueRandomSimulationStrategy(), iSearchParameters, 0.5, 1.0);
+                break;
+            case UCT_WPB_TR_C0_5_W1_5:
+                result = new TinyMonteCarloTreeSearchWPB(new TinyTrueRandomSimulationStrategy(), iSearchParameters, 0.5, 1.5);
+                break;
+            case UCT_WPB_TR_C0_5_W2_0:
+                result = new TinyMonteCarloTreeSearchWPB(new TinyTrueRandomSimulationStrategy(), iSearchParameters, 0.5, 2.0);
+                break;
+
+            case UCT_PB_TR_C0_5_W0_4:
+                result = new TinyMonteCarloTreeSearchPB(new TinyTrueRandomSimulationStrategy(), iSearchParameters, 0.5, 0.4);
                 break;
             default:
                 assert false : "Unknown game strategy!";

--- a/src/main/kingdominoplayer/tinyrepresentation/gamestrategies/TinyStrategyID.java
+++ b/src/main/kingdominoplayer/tinyrepresentation/gamestrategies/TinyStrategyID.java
@@ -21,34 +21,37 @@ public enum TinyStrategyID
     MCE_EG_R,
     MCE_PG_R,
 
-    // for examining UCB constant
-    UCT_TR_C0_1_W0_0,
-    UCT_TR_C0_2_W0_0,
-    UCT_TR_C0_3_W0_0,
-    UCT_TR_C0_4_W0_0,
-    UCT_TR_C0_5_W0_0,
-    UCT_TR_C0_6_W0_0,
-    UCT_TR_C1_0_W0_0,
-    UCT_TR_C1_5_W0_0,
-    UCT_TR_C2_0_W0_0,
+    // Regular Monte-Carlo Tree Search (UTC)
+    UCT_TR_C0_1,
+    UCT_TR_C0_2,
+    UCT_TR_C0_3,
+    UCT_TR_C0_4,
+    UCT_TR_C0_5,
+    UCT_TR_C0_6,
+    UCT_TR_C1_0,
+    UCT_TR_C1_5,
+    UCT_TR_C2_0,
 
-    UCT_FG_C0_1_W0_0,
-    UCT_FG_C0_2_W0_0,
-    UCT_FG_C0_3_W0_0,
-    UCT_FG_C0_4_W0_0,
-    UCT_FG_C0_5_W0_0,
-    UCT_FG_C0_6_W0_0,
-    UCT_FG_C1_0_W0_0,
-    UCT_FG_C1_5_W0_0,
-    UCT_FG_C2_0_W0_0,
+    UCT_FG_C0_1,
+    UCT_FG_C0_2,
+    UCT_FG_C0_3,
+    UCT_FG_C0_4,
+    UCT_FG_C0_5,
+    UCT_FG_C0_6,
+    UCT_FG_C1_0,
+    UCT_FG_C1_5,
+    UCT_FG_C2_0,
 
-    // for examining bias weight
-    UCT_TR_C0_5_W0_1,
-    UCT_TR_C0_5_W0_2,
-    UCT_TR_C0_5_W0_3,
-    UCT_TR_C0_5_W0_4,
-    UCT_TR_C0_5_W0_5,
-    UCT_TR_C0_5_W1_0,
-    UCT_TR_C0_5_W1_5,
-    UCT_TR_C0_5_W2_0
+    // Monte-Carlo Tree Search with Win-Persistent Progressive Bias (UTC_WPB)
+    UCT_WPB_TR_C0_5_W0_1,
+    UCT_WPB_TR_C0_5_W0_2,
+    UCT_WPB_TR_C0_5_W0_3,
+    UCT_WPB_TR_C0_5_W0_4,
+    UCT_WPB_TR_C0_5_W0_5,
+    UCT_WPB_TR_C0_5_W1_0,
+    UCT_WPB_TR_C0_5_W1_5,
+    UCT_WPB_TR_C0_5_W2_0,
+
+    // Monte-Carlo Tree Search with Progressive Bias (UTC_PB)
+    UCT_PB_TR_C0_5_W0_4
 }

--- a/src/main/kingdominoplayer/tinyrepresentation/search/montecarlo/treesearch/ucts/UCB.java
+++ b/src/main/kingdominoplayer/tinyrepresentation/search/montecarlo/treesearch/ucts/UCB.java
@@ -1,0 +1,30 @@
+package kingdominoplayer.tinyrepresentation.search.montecarlo.treesearch.ucts;
+
+/*
+ * Copyright 2018 Tomologic AB<br>
+ * User: gedda<br>
+ * Date: 2018-01-23<br>
+ * Time: 20:46<br><br>
+ */
+
+public class UCB
+{
+
+    protected final double iExplorationFactor;
+
+    public UCB(final double explorationFactor)
+    {
+        iExplorationFactor = explorationFactor;
+    }
+
+    public double getUCB(final UCTSNode node)
+    {
+        final UCTSNode parent = node.getParent();
+
+        final double exploit = (double) node.getWins() / (double) node.getVisits();
+        final double explore = Math.sqrt(Math.log(parent.getVisits()) / (double) node.getVisits());
+
+        return exploit + iExplorationFactor * explore;
+    }
+
+}

--- a/src/main/kingdominoplayer/tinyrepresentation/search/montecarlo/treesearch/ucts/UCBProgressiveBias.java
+++ b/src/main/kingdominoplayer/tinyrepresentation/search/montecarlo/treesearch/ucts/UCBProgressiveBias.java
@@ -1,0 +1,33 @@
+package kingdominoplayer.tinyrepresentation.search.montecarlo.treesearch.ucts;
+
+/*
+ * Copyright 2018 Tomologic AB<br>
+ * User: gedda<br>
+ * Date: 2018-01-23<br>
+ * Time: 20:54<br><br>
+ */
+
+public class UCBProgressiveBias extends UCB
+{
+    private final double iBiasWeight;
+
+    public UCBProgressiveBias(final double exploringFactor, final double biasWeight)
+    {
+        super(exploringFactor);
+        iBiasWeight = biasWeight;
+    }
+
+    @Override
+    public double getUCB(final UCTSNode node)
+    {
+        final UCTSNode parent = node.getParent();
+
+        final String player = parent.getPlayerTurn();
+        final int scoreBeforeMove = parent.getGameState().getScore(player);
+        final int scoreAfterMove = node.getGameState().getScore(player);
+        final double heuristic = scoreAfterMove - scoreBeforeMove;
+        final double bias = iBiasWeight * heuristic / (node.getVisits() + 1);
+
+        return super.getUCB(node) + bias;
+    }
+}

--- a/src/main/kingdominoplayer/tinyrepresentation/search/montecarlo/treesearch/ucts/UCBWinPersistentProgressiveBias.java
+++ b/src/main/kingdominoplayer/tinyrepresentation/search/montecarlo/treesearch/ucts/UCBWinPersistentProgressiveBias.java
@@ -1,0 +1,37 @@
+package kingdominoplayer.tinyrepresentation.search.montecarlo.treesearch.ucts;
+
+/*
+ * Copyright 2018 Tomologic AB<br>
+ * User: gedda<br>
+ * Date: 2018-01-23<br>
+ * Time: 20:48<br><br>
+ */
+
+public class UCBWinPersistentProgressiveBias extends UCB
+{
+
+    private final double iBiasWeight;
+
+    public UCBWinPersistentProgressiveBias(final double exploringFactor, final double biasWeight)
+    {
+        super(exploringFactor);
+        iBiasWeight = biasWeight;
+    }
+
+    @Override
+    public double getUCB(final UCTSNode node)
+    {
+        final UCTSNode parent = node.getParent();
+
+        final double exploit = (double) node.getWins() / (double) node.getVisits();
+
+        final String player = parent.getPlayerTurn();
+        final int scoreBeforeMove = parent.getGameState().getScore(player);
+        final int scoreAfterMove = node.getGameState().getScore(player);
+        final double heuristic = scoreAfterMove - scoreBeforeMove;
+        final double bias = iBiasWeight * heuristic / (node.getVisits() * (1.0 - exploit) + 1);
+
+        return super.getUCB(node) + bias;
+    }
+
+}

--- a/src/main/kingdominoplayer/tinyrepresentation/search/montecarlo/treesearch/ucts/UCTSNode.java
+++ b/src/main/kingdominoplayer/tinyrepresentation/search/montecarlo/treesearch/ucts/UCTSNode.java
@@ -118,7 +118,7 @@ import java.util.Map;
 
 
 
-    public String toStringNestedBrackets(final ArrayList<Integer> depthIndices, final double exploreFactor, final double biasWeight)
+    public String toStringNestedBrackets(final ArrayList<Integer> depthIndices, final UCB ucb)
     {
         String nodeString = "";
 
@@ -145,7 +145,7 @@ import java.util.Map;
 
         if (iParent != null)
         {
-            final double upperConfidenceBound = UCTSTreeUtils.getUCB(this, exploreFactor, biasWeight);
+            final double upperConfidenceBound = ucb.getUCB(this);
             nodeString = nodeString.concat(", UCB: ").concat(String.format("%.5f", upperConfidenceBound));
         }
 

--- a/src/main/kingdominoplayer/tinyrepresentation/search/montecarlo/treesearch/ucts/UCTSTreeUtils.java
+++ b/src/main/kingdominoplayer/tinyrepresentation/search/montecarlo/treesearch/ucts/UCTSTreeUtils.java
@@ -12,49 +12,28 @@ import java.util.ArrayList;
 
 /*package*/ class UCTSTreeUtils
 {
-    public static double getUCB(final UCTSNode node, final double exploreFactor, double biasWeight)
-    {
-        final UCTSNode parent = node.getParent();
 
-        final double exploit = (double) node.getWins() / (double) node.getVisits();
-        final double explore = Math.sqrt(Math.log(parent.getVisits()) / (double) node.getVisits());
-
-        // Win-persistent progressive bias
-        double bias = 0.0;
-        if (biasWeight > 0)
-        {
-            final String player = parent.getPlayerTurn();
-            final int scoreBeforeMove = parent.getGameState().getScore(player);
-            final int scoreAfterMove = node.getGameState().getScore(player);
-            final double heuristic = scoreAfterMove - scoreBeforeMove;
-            bias = biasWeight * heuristic / (node.getVisits() * (1.0 - exploit) + 1);
-        }
-
-        return exploit + exploreFactor * explore + bias;
-    }
-
-
-    public static void printTree(final UCTSNode root, final double exploreFactor, final double biasWeight)
+    public static void printTree(final UCTSNode root, final UCB ucb)
     {
         System.out.println("Monte-Carlo Search Tree:");
-        printTree(root, new ArrayList<>(), exploreFactor, biasWeight);
+        printTree(root, new ArrayList<>(), ucb);
     }
 
 
-    public static void printChildren(final UCTSNode node, final double exploreFactor, final double biasWeight)
+    public static void printChildren(final UCTSNode node, final UCB ucb)
     {
         int counter = 0;
         for (final UCTSNode child : node.getChildren())
         {
             final ArrayList<Integer> depthIndices = new ArrayList<>();
             depthIndices.add(counter++);
-            System.out.println(child.toStringNestedBrackets(depthIndices, exploreFactor, biasWeight));
+            System.out.println(child.toStringNestedBrackets(depthIndices, ucb));
         }
     }
 
-    private static void printTree(final UCTSNode node, final ArrayList<Integer> depthIndices, final double exploreFactor, final double biasWeight)
+    private static void printTree(final UCTSNode node, final ArrayList<Integer> depthIndices, final UCB ucb)
     {
-        String nodeString = node.toStringNestedBrackets(depthIndices, exploreFactor, biasWeight);
+        String nodeString = node.toStringNestedBrackets(depthIndices, ucb);
 
         System.out.println(nodeString);
 
@@ -66,16 +45,16 @@ import java.util.ArrayList;
             indices.addAll(depthIndices);
             indices.add(i);
 
-            printTree(children.get(i), indices, exploreFactor, biasWeight);
+            printTree(children.get(i), indices, ucb);
         }
     }
 
-    public static void printTreeBFS(final UCTSNode root, final double exploreFactor, final double biasWeight)
+    public static void printTreeBFS(final UCTSNode root, final UCB ucb)
     {
-        printTreeBFS(root, -1, exploreFactor, biasWeight);
+        printTreeBFS(root, -1, ucb);
     }
 
-    public static void printTreeBFS(final UCTSNode root, final long numNodes, final double exploreFactor, final double biasWeight)
+    public static void printTreeBFS(final UCTSNode root, final long numNodes, final UCB ucb)
     {
         final ArrayDeque<NodeDepthIndicesPair> nodeQueue = new ArrayDeque<>(1000);
 
@@ -89,7 +68,7 @@ import java.util.ArrayList;
             final NodeDepthIndicesPair current = nodeQueue.pop();
             final UCTSNode node = current.iNode;
 
-            final String nodeString = node.toStringNestedBrackets(current.iDepthIndices, exploreFactor, biasWeight);
+            final String nodeString = node.toStringNestedBrackets(current.iDepthIndices, ucb);
             System.out.println(nodeString);
 
             final ArrayList<UCTSNode> children = node.getChildren();


### PR DESCRIPTION
Add Monte-Carlo Tree Search strategy (UCT) with Progressive Bias enhancement.

Includes a refactoring where the old TinyStrategy TinyMonteCarloTreeSearch is split into the two strategies it represented (regular UCT and UCT with Win-Persistent Progressive Bias).